### PR TITLE
Release 0.0.1+3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.0.1+3
+
+* Added `\hat` implementation that works for small letters.
+
 ## 0.0.1+2
 
-* Fix `\frac` line positioning.
+* Fixed `\frac` line positioning.
 
 ## 0.0.1+1
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -47,3 +47,5 @@ app.*.map.json
 android
 ios
 web
+test
+.metadata

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,6 +20,7 @@ List<String> get equations => [
       r'\KaTeX',
       r'\CaTeX',
       'x_i=a^n',
+      r'\hat{y} = H y',
       r'12^{\frac{\frac{2}{7}}{1}}',
       r'\varepsilon = \frac{\frac{2}{1}}{3}',
       r'\alpha\beta\gamma\delta',

--- a/function_prioritization.csv
+++ b/function_prioritization.csv
@@ -61,7 +61,7 @@ function,supported,frequency
 \overline,false,115
 \Delta,true,114
 \omega,true,110
-\hat,false,103
+\hat,trueish,103
 \varepsilon,true,101
 \textbf,true,93
 \lim,false,92

--- a/lib/src/lookup/functions.dart
+++ b/lib/src/lookup/functions.dart
@@ -25,11 +25,11 @@ import 'package:flutter/foundation.dart';
 /// manual work seems reasonable.
 /// Either way, the conversion will be a simple process.
 enum CaTeXFunction {
-  /// `\hat{}` applies hat to the content of bracket
-  hat,
-
   /// `\frac{}{}` displays a fraction.
   frac,
+
+  /// `\hat{}` displays a hat above its group.
+  hat,
 
   /// `\tt{}` uses the [CaTeXFont.typewriter] font.
   tt,
@@ -117,8 +117,8 @@ enum CaTeXFunction {
 /// a CaTeX function. See [_lookupFunctionData] to find the
 /// function definitions and explanations in the classes.
 const supportedFunctionNames = <String, CaTeXFunction>{
-  r'\hat': CaTeXFunction.hat,
   r'\frac': CaTeXFunction.frac,
+  r'\hat': CaTeXFunction.hat,
   r'\tt': CaTeXFunction.tt,
   r'\rm': CaTeXFunction.rm,
   r'\sf': CaTeXFunction.sf,

--- a/lib/src/parsing/functions/hat.dart
+++ b/lib/src/parsing/functions/hat.dart
@@ -5,7 +5,11 @@ import 'package:catex/src/rendering/functions/hat.dart';
 import 'package:catex/src/rendering/rendering.dart';
 import 'package:catex/src/widgets.dart';
 
+// todo: probably create an accent node to group accents together
+// todo| https://github.com/KaTeX/KaTeX/blob/fa8fbc0c18e5e3fe98f347ceed3a48699d561c72/src/functions/accent.js
+/// [ParsingNode] for [CaTeXFunction.hat].
 class HatNode extends SingleChildNode with FunctionNode {
+  /// Constructs a [HatNode] given a [context].
   HatNode(ParsingContext context) : super(context);
 
   @override
@@ -15,6 +19,7 @@ class HatNode extends SingleChildNode with FunctionNode {
   @override
   NodeWidget configureWidget(CaTeXContext context) {
     super.configureWidget(context);
+
     return NodeWidget(
       context,
       createRenderNode,

--- a/lib/src/rendering/functions/hat.dart
+++ b/lib/src/rendering/functions/hat.dart
@@ -4,32 +4,53 @@ import 'dart:ui';
 import 'package:catex/src/lookup/context.dart';
 import 'package:catex/src/lookup/modes.dart';
 import 'package:catex/src/lookup/symbols.dart';
+import 'package:catex/src/parsing/functions/hat.dart';
 import 'package:catex/src/rendering/character.dart';
 import 'package:catex/src/rendering/rendering.dart';
 import 'package:flutter/rendering.dart';
 
+// todo: this has many inaccuracies; refer to
+// todo| https://github.com/KaTeX/KaTeX/blob/fa8fbc0c18e5e3fe98f347ceed3a48699d561c72/src/functions/accent.js
+/// [RenderNode] for [HatNode].
 class RenderHat extends RenderNode with SingleChildRenderNodeMixin {
+  /// Constructs a [HatNode] given a [context].
   RenderHat(CaTeXContext context) : super(context);
 
   TextPainter _hatPainter;
 
   @override
   void configure() {
-    _hatPainter = TypesetPainter(
-        context.copyWith(input: symbols[CaTeXMode.math][r'\hat'].unicode));
+    _hatPainter = TypesetPainter(context.copyWith(
+      input: symbols[CaTeXMode.math][r'\hat'].unicode,
+    ));
+    // todo: remove this workaround and implement accents properly
+    // todo| see above
+    final upperCase = child.context.input.trim().isNotEmpty &&
+        child.context.input.toUpperCase() == child.context.input;
 
     _hatPainter.layout();
     final childSize = sizeChildNode(child),
         hatSize = _hatPainter.size,
-        height = max(hatSize.height, childSize.height);
+        // todo: width needs to be only the bounds of the hat
+        width = max(hatSize.width, childSize.width),
+        height = max(hatSize.height, childSize.height) +
+            (upperCase ? hatSize.height / 10 : 0);
 
-    child.positionNode(Offset(0, height - childSize.height));
-    renderSize = Size(childSize.width, height);
+    child.positionNode(Offset(
+        0, height - childSize.height + (upperCase ? hatSize.height / 10 : 0)));
+    renderSize = Size(width, height);
   }
 
   @override
   void render(Canvas canvas) {
     paintChildNode(child);
-    _hatPainter.paint(canvas, Offset(child.size.width / 4, 0));
+
+    _hatPainter.paint(
+      canvas,
+      Offset(
+        max(0, child.renderSize.width / 2 - _hatPainter.size.width / 3),
+        0,
+      ),
+    );
   }
 }

--- a/lib/src/rendering/functions/sqrt.dart
+++ b/lib/src/rendering/functions/sqrt.dart
@@ -21,7 +21,7 @@ class RenderSqrt extends RenderNode with SingleChildRenderNodeMixin {
       ..strokeWidth = context.textSize / 20
       ..strokeCap = StrokeCap.square;
     _surdPainter = TypesetPainter(
-        context.copyWith(input: symbols[CaTeXMode.math][r'\surd'].unicode));
+        context.copyWith(input: symbols[CaTeXMode.math][r'\surd'].unicode),);
 
     _surdPainter.layout();
     final childSize = sizeChildNode(child),

--- a/lib/src/rendering/functions/sqrt.dart
+++ b/lib/src/rendering/functions/sqrt.dart
@@ -21,7 +21,8 @@ class RenderSqrt extends RenderNode with SingleChildRenderNodeMixin {
       ..strokeWidth = context.textSize / 20
       ..strokeCap = StrokeCap.square;
     _surdPainter = TypesetPainter(
-        context.copyWith(input: symbols[CaTeXMode.math][r'\surd'].unicode),);
+      context.copyWith(input: symbols[CaTeXMode.math][r'\surd'].unicode),
+    );
 
     _surdPainter.layout();
     final childSize = sizeChildNode(child),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: catex
 description: >-
   Fast math TeX renderer for Flutter written in Dart. Outputs TeX formulas (like LaTeX,
   KaTeX, MathJax, etc.) inline using only Flutter.
-version: 0.0.1+2
+version: 0.0.1+3
 homepage: https://github.com/simpleclub/CaTeX
 
 environment:


### PR DESCRIPTION
## Description

Acknowledges the incompleteness of #45.

## Related issues & PRs

* Publishes #51.
* Publishes #45.

* #41 will ensure that only `renderSize` will be used (which was one of the issues here).

## Checklist

- [x] I added a PR description.
- [x] I linked all related issues I could find.
- [x] If this PR changes anything about the main `catex` or `example` package (also README etc.),
      I created an entry in `CHANGELOG.md` (`## NEXT RELEASE` if it is not worth an update).
- [x] If this PR includes a notable change in the `catex` package, I updated the version according
      to [Dart's semantic versioning](https://dart.dev/tools/pub/versioning#semantic-versions).
- [x] If this PR adds new functions, I updated the `function_prioritization.csv` file.
- [x] All required checks pass.
