### PR TITLE
add \cancel function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UPCOMING RELEASE
 
-* Add \cancel function.
+* Add `\cancel` function.
 
 ## 0.0.1+7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UPCOMING RELEASE
+## 0.0.1+8
 
 * Add `\cancel` function.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UPCOMING RELEASE
+
+* Add \cancel function.
+
 ## 0.0.1+7
 
 * Added on-hold notice.

--- a/function_prioritization.csv
+++ b/function_prioritization.csv
@@ -337,7 +337,7 @@ _,false,0
 \Bumpeq,false,0
 \bumpeq,false,0
 \cal,true,0
-\cancel,false,0
+\cancel,true,0
 \cancelto,false,0
 \Cap,false,0
 {cases},false,0

--- a/lib/src/lookup/functions.dart
+++ b/lib/src/lookup/functions.dart
@@ -2,6 +2,7 @@ import 'package:catex/src/lookup/fonts.dart';
 import 'package:catex/src/lookup/modes.dart';
 import 'package:catex/src/lookup/styles.dart';
 import 'package:catex/src/parsing/functions/boxed.dart';
+import 'package:catex/src/parsing/functions/cancel.dart';
 import 'package:catex/src/parsing/functions/color_box.dart';
 import 'package:catex/src/parsing/functions/font.dart';
 import 'package:catex/src/parsing/functions/frac.dart';
@@ -114,6 +115,9 @@ enum CaTeXFunction {
 
   /// `\mathbb{}` uses the [CaTeXFont.ams] font.
   mathbb,
+
+  /// `\cancel{}` draws a slash from the top right to the bottom left corners.
+  cancel,
 }
 
 /// Names, i.e. control sequences that correspond to
@@ -150,6 +154,7 @@ const supportedFunctionNames = <String, CaTeXFunction>{
   r'\kern': CaTeXFunction.kern,
   r'\raisebox': CaTeXFunction.raiseBox,
   r'\mathbb': CaTeXFunction.mathbb,
+  r'\cancel': CaTeXFunction.cancel,
 };
 
 /// CaTeX functions that are available in math mode.
@@ -184,6 +189,7 @@ const List<CaTeXFunction> supportedMathFunctions = [
   CaTeXFunction.textIt,
   CaTeXFunction.textUp,
   CaTeXFunction.mathbb,
+  CaTeXFunction.cancel,
 ];
 
 /// CaTeX functions that are available in text mode.
@@ -212,6 +218,7 @@ const List<CaTeXFunction> supportedTextFunctions = [
   CaTeXFunction.textMd,
   CaTeXFunction.textIt,
   CaTeXFunction.textUp,
+  CaTeXFunction.cancel,
 ];
 
 /// Looks up the [FunctionNode] subclass for a given input.
@@ -263,6 +270,8 @@ FunctionNode lookupFunction(ParsingContext context) {
       return RaiseBoxNode(context);
     case CaTeXFunction.kern:
       return KernNode(context);
+    case CaTeXFunction.cancel:
+      return CancelNode(context);
     case CaTeXFunction.displayStyle:
     case CaTeXFunction.textStyle:
     case CaTeXFunction.scriptStyle:

--- a/lib/src/lookup/functions.dart
+++ b/lib/src/lookup/functions.dart
@@ -218,7 +218,6 @@ const List<CaTeXFunction> supportedTextFunctions = [
   CaTeXFunction.textMd,
   CaTeXFunction.textIt,
   CaTeXFunction.textUp,
-  CaTeXFunction.cancel,
 ];
 
 /// Looks up the [FunctionNode] subclass for a given input.

--- a/lib/src/parsing/functions/cancel.dart
+++ b/lib/src/parsing/functions/cancel.dart
@@ -1,0 +1,36 @@
+import 'package:catex/src/lookup/context.dart';
+import 'package:catex/src/lookup/functions.dart';
+import 'package:catex/src/parsing/parsing.dart';
+import 'package:catex/src/rendering/functions/cancel.dart';
+import 'package:catex/src/widgets.dart';
+
+// todo: probably create an accent node to group accents together
+// todo| https://github.com/KaTeX/KaTeX/blob/fa8fbc0c18e5e3fe98f347ceed3a48699d561c72/src/functions/accent.js
+/// [ParsingNode] for [CaTeXFunction.cancel].
+class CancelNode extends SingleChildNode<RenderCancel>
+    with FunctionNode<RenderCancel> {
+  /// Constructs a [CancelNode] given a [context].
+  CancelNode(ParsingContext context) : super(context);
+
+  @override
+  FunctionProperties get properties =>
+      const FunctionProperties(arguments: 1, greediness: 1);
+
+  @override
+  NodeWidget<RenderCancel> configureWidget(CaTeXContext context) {
+    super.configureWidget(context);
+
+    return NodeWidget(
+      context,
+      createRenderNode,
+      children: [
+        child.createWidget(context),
+      ],
+    );
+  }
+
+  @override
+  RenderCancel createRenderNode(CaTeXContext context) {
+    return RenderCancel(context);
+  }
+}

--- a/lib/src/rendering/functions/cancel.dart
+++ b/lib/src/rendering/functions/cancel.dart
@@ -24,10 +24,12 @@ class RenderCancel extends RenderNode {
   @override
   void render(Canvas canvas) {
     paintChildNode(children[0]);
+    final double horizontalPadding = renderSize.width * .05;
+    final double verticalPadding = renderSize.height * .05;
 
     canvas.drawLine(
-      Offset(renderSize.width, 0),
-      Offset(0, renderSize.height),
+      Offset(renderSize.width - horizontalPadding, verticalPadding),
+      Offset(horizontalPadding, renderSize.height - verticalPadding),
       _linePaint,
     );
   }

--- a/lib/src/rendering/functions/cancel.dart
+++ b/lib/src/rendering/functions/cancel.dart
@@ -1,0 +1,34 @@
+import 'dart:ui';
+
+import 'package:catex/src/lookup/context.dart';
+import 'package:catex/src/rendering/rendering.dart';
+
+/// [RenderNode] for [CancelNode].
+class RenderCancel extends RenderNode {
+  /// Constructs a [RenderCancel] given a [context].
+  RenderCancel(CaTeXContext context) : super(context);
+
+  Paint _linePaint;
+
+  @override
+  void configure() {
+    final childSize = sizeChildNode(children[0]);
+
+    renderSize = childSize;
+
+    _linePaint = Paint()
+      ..strokeWidth = 2
+      ..color = context.color;
+  }
+
+  @override
+  void render(Canvas canvas) {
+    paintChildNode(children[0]);
+
+    canvas.drawLine(
+      Offset(renderSize.width, 0),
+      Offset(0, renderSize.height),
+      _linePaint,
+    );
+  }
+}

--- a/lib/src/rendering/functions/cancel.dart
+++ b/lib/src/rendering/functions/cancel.dart
@@ -8,29 +8,25 @@ class RenderCancel extends RenderNode {
   /// Constructs a [RenderCancel] given a [context].
   RenderCancel(CaTeXContext context) : super(context);
 
-  Paint _linePaint;
-
   @override
   void configure() {
-    final childSize = sizeChildNode(children[0]);
-
-    renderSize = childSize;
-
-    _linePaint = Paint()
-      ..strokeWidth = 2
-      ..color = context.color;
+    renderSize = sizeChildNode(children[0]);
   }
 
   @override
   void render(Canvas canvas) {
+    final linePaint = Paint()
+      ..strokeWidth = 2
+      ..color = context.color;
+
     paintChildNode(children[0]);
-    final double horizontalPadding = renderSize.width * .05;
-    final double verticalPadding = renderSize.height * .05;
+    final horizontalPadding = renderSize.width * .05;
+    final verticalPadding = renderSize.height * .05;
 
     canvas.drawLine(
       Offset(renderSize.width - horizontalPadding, verticalPadding),
       Offset(horizontalPadding, renderSize.height - verticalPadding),
-      _linePaint,
+      linePaint,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: catex
 description: >-
   Fast math TeX renderer for Flutter written in Dart. Outputs TeX formulas (like LaTeX,
   KaTeX, MathJax, etc.) inline using only Flutter.
-version: 0.0.1+7
+version: 0.0.1+8
 homepage: https://github.com/simpleclub/CaTeX
 
 environment:


### PR DESCRIPTION
## Description

This PR adds a single operand function \cancel which draws a slash from the bottom left corner to the top right corner of the child as described by http://tug.ctan.org/tex-archive/macros/latex/contrib/cancel/cancel.pdf

## Checklist

*Remove `If [...]` items that do not apply to your PR.*

- [x] I have made myself familiar with the CaTeX
      [contributing guide](https://github.com/simpleclub/CaTeX/blob/master/CONTRIBUTING.md).
- [X] I added a PR description.
- [X] If this PR changes anything about the main `catex` or `example` package (also README etc.),
      I created an entry in `CHANGELOG.md` (`## UPCOMING RELEASE` if the change on its own
      is not worth an update).
- [X] If this PR adds new functions, I updated the `function_prioritization.csv` file.
- [x] If there is new functionality in code, I added tests covering all my additions
      (Golden tests for anything rendering related). - I didn't see any place to add golden tests.
- [X] All required checks pass.
